### PR TITLE
Fix Footer: Remove Endif

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -52,8 +52,6 @@
 
  </footer><!-- end #colophon -->
 
-<?php endif; ?>
-
 <?php wp_footer(); ?>
 
 </body>


### PR DESCRIPTION
It appears that the `<?php endif; ?>` statement is unnecessary and is causing an error. There is no matching if statement in the code preceding it. Once I remove the `<?php endif; ?>` statement, the footer works as expected.

close #1 